### PR TITLE
fix: report file size limits correctly in image validation errors

### DIFF
--- a/care/utils/models/validators.py
+++ b/care/utils/models/validators.py
@@ -250,13 +250,20 @@ class ImageSizeValidator:
             ]
         )
 
-    def _humanize_bytes(self, size: int) -> str:
+    @staticmethod
+    def _format_size(size: float) -> str:
+        # Trim the trailing zeros of the fixed-point form first, then the bare
+        # decimal point. Stripping "." and "0" in one pass also eats the
+        # significant zeros of a round number, turning 10.00 into "1".
+        return f"{size:.2f}".rstrip("0").rstrip(".")
+
+    def _humanize_bytes(self, size: float) -> str:
         byte_size = 1024.0
         for unit in ["B", "KB"]:
             if size < byte_size:
-                return f"{f'{size:.2f}'.rstrip('.0')} {unit}"
+                return f"{self._format_size(size)} {unit}"
             size /= byte_size
-        return f"{f'{size:.2f}'.rstrip('.0')} MB"
+        return f"{self._format_size(size)} MB"
 
 
 cover_image_validator = ImageSizeValidator(

--- a/care/utils/tests/test_image_validator.py
+++ b/care/utils/tests/test_image_validator.py
@@ -60,3 +60,37 @@ class CoverImageValidatorTests(TestCase):
                 "Image size is greater than the maximum allowed size of 2 MB.",
             ],
         )
+
+    def _image_file(self, reported_size: int) -> UploadedFile:
+        image = Image.new("RGB", (10, 10))
+        file = io.BytesIO()
+        image.save(file, format="JPEG")
+        return UploadedFile(file, "test.jpg", "image/jpeg", reported_size)
+
+    def test_min_size_limit_is_reported_verbatim(self):
+        for min_size, expected in [
+            (500, "500 B"),
+            (1536, "1.5 KB"),
+            (10 * 1024, "10 KB"),
+            (10 * 1024 * 1024, "10 MB"),
+        ]:
+            with self.subTest(min_size=min_size):
+                validator = ImageSizeValidator(min_size=min_size)
+                with self.assertRaises(ValidationError) as cm:
+                    validator(self._image_file(1))
+                self.assertEqual(
+                    cm.exception.messages,
+                    [
+                        "Image size is less than the minimum allowed size of "
+                        f"{expected}.",
+                    ],
+                )
+
+    def test_max_size_limit_is_reported_verbatim(self):
+        validator = ImageSizeValidator(max_size=10 * 1024 * 1024)
+        with self.assertRaises(ValidationError) as cm:
+            validator(self._image_file(20 * 1024 * 1024))
+        self.assertEqual(
+            cm.exception.messages,
+            ["Image size is greater than the maximum allowed size of 10 MB."],
+        )


### PR DESCRIPTION
`ImageSizeValidator._humanize_bytes` formats a byte count and then trims it with `rstrip(".0")`:

```python
return f"{f'{size:.2f}'.rstrip('.0')} {unit}"
```

`rstrip` takes a set of characters, not a suffix, so it keeps eating trailing `.` and `0` past the decimal point and into the number itself. Any round size that ends in a zero comes out wrong:

| bytes | message says | should say |
|---|---|---|
| 10 * 1024 | 1 KB | 10 KB |
| 100 * 1024 | 1 KB | 100 KB |
| 10 * 1024 * 1024 | 1 MB | 10 MB |
| 500 | 5 B | 500 B |
| 0 | (empty) B | 0 B |

So a validator configured with a 10 MB ceiling tells the user their image is "greater than the maximum allowed size of 1 MB".

The two values wired up today, `cover_image_validator`'s 1 KB minimum and 2 MB maximum, happen to survive the strip, which is why the existing tests pass and nobody has hit it yet. Any other limit is misreported.

Fix is to strip the trailing zeros first and the bare decimal point second, which cannot reach a significant digit:

```python
f"{size:.2f}".rstrip("0").rstrip(".")
```

Added two tests that assert the rendered message for 500 B, 1.5 KB, 10 KB and 10 MB limits, going through the public validator rather than the helper. Both fail on the current code.

A note on verification: I could not run the Django suite here (no local Postgres or project settings), so I checked the formatting change by running the old and new helper side by side over 12 sizes, and confirmed ruff check and ruff format are clean on both files. The assertions in the new tests are the exact strings from the message templates, but CI is the real check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image size limit messages to display accurate, human-readable values across bytes, kilobytes, and megabytes.
  * Ensured minimum and maximum image size validation errors report the configured thresholds consistently.

* **Tests**
  * Added coverage for image size formatting and validation messages across multiple size units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->