### PR TITLE
[ENG-867] fix:Ignore unique checks on empty identifiers

### DIFF
--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -80,23 +80,20 @@ class PatientBaseSpec(EMRResource):
 
 
 def validate_identifier_config(config, value, obj=None):
-    queryset = PatientIdentifier.objects.filter(value=value)
-    if "config_obj" in config:
-        queryset = queryset.filter(config=config["config_obj"])
-    else:
-        queryset = queryset.filter(config__external_id=config["id"])
-    if obj:
-        queryset = queryset.exclude(patient=obj)
-    if value and config["config"]["unique"] and queryset.exists():
-        err = f"Identifier config {config['config']['system']} is not unique"
-        raise ValueError(err)
-    if (
-        value
-        and config["config"]["regex"]
-        and not re.match(config["config"]["regex"], value)
-    ):
-        err = f"Identifier config {config['config']['system']} is not valid"
-        raise ValueError(err)
+    if value:
+        queryset = PatientIdentifier.objects.filter(value=value)
+        if "config_obj" in config:
+            queryset = queryset.filter(config=config["config_obj"])
+        else:
+            queryset = queryset.filter(config__external_id=config["id"])
+        if obj:
+            queryset = queryset.exclude(patient=obj)
+        if config["config"]["unique"] and queryset.exists():
+            err = f"Identifier config {config['config']['system']} is not unique"
+            raise ValueError(err)
+        if config["config"]["regex"] and not re.match(config["config"]["regex"], value):
+            err = f"Identifier config {config['config']['system']} is not valid"
+            raise ValueError(err)
 
 
 class PatientIdentifierConfigRequest(BaseModel):

--- a/care/emr/resources/patient/spec.py
+++ b/care/emr/resources/patient/spec.py
@@ -87,7 +87,7 @@ def validate_identifier_config(config, value, obj=None):
         queryset = queryset.filter(config__external_id=config["id"])
     if obj:
         queryset = queryset.exclude(patient=obj)
-    if config["config"]["unique"] and queryset.exists():
+    if value and config["config"]["unique"] and queryset.exists():
         err = f"Identifier config {config['config']['system']} is not unique"
         raise ValueError(err)
     if (

--- a/care/emr/tests/test_patient_api.py
+++ b/care/emr/tests/test_patient_api.py
@@ -233,6 +233,115 @@ class TestPatientViewSet(CareAPITestBase):
         response = self.client.post(self.base_url, patient_data, format="json")
         self.assertEqual(response.status_code, 400)
 
+    def test_create_patient_with_unique_patient_identifier(self):
+        """
+        Test creating a patient with a unique identifier config and validating"""
+        user = self.create_user()
+        geo_organization = self.create_organization(org_type="govt")
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_create_patient.name]
+        )
+        self.attach_role_organization_user(geo_organization, user, role)
+        self.client.force_authenticate(user=user)
+        patient_data = self.generate_patient_data(
+            geo_organization=geo_organization.external_id
+        )
+        PatientCreateLock().release()
+        identifier_config = PatientIdentifierConfig.objects.create(
+            status="active",
+            config={
+                "use": "official",
+                "system": "test-identifier",
+                "required": False,
+                "unique": True,
+                "regex": "",
+                "display": "Test Identifier",
+            },
+        )
+        identifier_value = "UNIQUE-ID-12345"
+        patient_data["identifiers"] = [
+            {"config": str(identifier_config.external_id), "value": identifier_value}
+        ]
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        PatientCreateLock().release()
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["errors"][0]["msg"],
+            "Value error, Identifier config test-identifier is not unique",
+        )
+
+    def test_create_patient_with_non_unique_patient_identifier(self):
+        """
+        Test creating a patient with a non-unique identifier config and validating"""
+        user = self.create_user()
+        geo_organization = self.create_organization(org_type="govt")
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_create_patient.name]
+        )
+        self.attach_role_organization_user(geo_organization, user, role)
+        self.client.force_authenticate(user=user)
+        patient_data = self.generate_patient_data(
+            geo_organization=geo_organization.external_id
+        )
+        PatientCreateLock().release()
+        identifier_config = PatientIdentifierConfig.objects.create(
+            status="active",
+            config={
+                "use": "official",
+                "system": "test-identifier",
+                "required": False,
+                "unique": False,
+                "regex": "",
+                "display": "Test Identifier",
+            },
+        )
+        identifier_value = "NON-UNIQUE-ID-12345"
+        patient_data["identifiers"] = [
+            {"config": str(identifier_config.external_id), "value": identifier_value}
+        ]
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        PatientCreateLock().release()
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_create_patient_with_empty_string_identifier(self):
+        """
+        Test creating a patient with an identifier config and an empty string value and skipping validation for uniqueness"""
+        user = self.create_user()
+        geo_organization = self.create_organization(org_type="govt")
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_create_patient.name]
+        )
+        self.attach_role_organization_user(geo_organization, user, role)
+        self.client.force_authenticate(user=user)
+        patient_data = self.generate_patient_data(
+            geo_organization=geo_organization.external_id
+        )
+        PatientCreateLock().release()
+        identifier_config = PatientIdentifierConfig.objects.create(
+            status="active",
+            config={
+                "use": "official",
+                "system": "test-identifier",
+                "required": False,
+                "unique": False,
+                "regex": "",
+                "display": "Test Identifier",
+            },
+        )
+        identifier_value = "NON-UNIQUE-ID-12345"
+        patient_data["identifiers"] = [
+            {"config": str(identifier_config.external_id), "value": identifier_value}
+        ]
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        PatientCreateLock().release()
+        response = self.client.post(self.base_url, patient_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
     def test_delete_patient_as_superuser(self):
         superuser = self.create_super_user()
         geo_organization = self.create_organization(org_type="govt")


### PR DESCRIPTION
## Proposed Changes

- Ignored unique checks on empty identifiers .

### Associated Issue

- ENG-867

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty identifier values no longer trigger uniqueness validation errors.
  * Regex validation behavior remains unchanged.
  * Duplicate values are rejected for identifiers configured as unique.
  * Duplicate values are accepted for identifiers configured as non-unique.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->