### PR TITLE
[ENG-807] refact:made parent json update only on tag update

### DIFF
--- a/care/emr/models/tag_config.py
+++ b/care/emr/models/tag_config.py
@@ -80,12 +80,18 @@ class TagConfig(EMRBaseModel):
                     "parent": self.parent.cached_parent_json,
                     "level_cache": self.parent.level_cache,
                 }
-                super().save(update_fields=["cached_parent_json"])
+                TagConfig.objects.filter(pk=self.pk).update(
+                    cached_parent_json=self.cached_parent_json
+                )
 
-    def update_child_cached_parent_json(self):
-        for child in TagConfig.objects.filter(parent=self).select_related("parent"):
-            child.update_parent_json()
-            child.update_child_cached_parent_json()
+    def update_descendants_cached_parent_json(self):
+        descendants = (
+            TagConfig.objects.filter(parent_cache__overlap=[self.id])
+            .select_related("parent")
+            .order_by("level_cache")
+        )
+        for descendant in descendants:
+            descendant.update_parent_json()
 
     def save(self, *args, **kwargs):
         if not self.id:
@@ -95,4 +101,4 @@ class TagConfig(EMRBaseModel):
         else:
             super().save(*args, **kwargs)
             self.update_parent_json()
-            self.update_child_cached_parent_json()
+            self.update_descendants_cached_parent_json()

--- a/care/emr/models/tag_config.py
+++ b/care/emr/models/tag_config.py
@@ -1,10 +1,8 @@
-from datetime import datetime, timedelta
-
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.utils import timezone
 
 from care.emr.models import EMRBaseModel
+from care.utils.lock import Lock
 
 
 class TagConfig(EMRBaseModel):
@@ -53,8 +51,6 @@ class TagConfig(EMRBaseModel):
     resource = models.CharField(max_length=255)
     metadata = models.JSONField(default=None, null=True, blank=True)
 
-    cache_expiry_days = 15
-
     def set_tag_config_cache(self):
         if self.parent:
             self.parent_cache = [*self.parent.parent_cache, self.parent.id]
@@ -69,30 +65,34 @@ class TagConfig(EMRBaseModel):
         super().save()
 
     def get_parent_json(self):
-        if self.parent_id:
-            if self.cached_parent_json and timezone.now() < datetime.fromisoformat(
-                self.cached_parent_json["cache_expiry"]
-            ):
-                return self.cached_parent_json
-            self.parent.get_parent_json()
-            self.cached_parent_json = {
-                "id": str(self.parent.external_id),
-                "display": self.parent.display,
-                "description": self.parent.description,
-                "category": self.parent.category,
-                "parent": self.parent.cached_parent_json,
-                "level_cache": self.parent.level_cache,
-                "cache_expiry": str(
-                    timezone.now() + timedelta(days=self.cache_expiry_days)
-                ),
-            }
-            self.save(update_fields=["cached_parent_json"])
+        if self.parent_id and self.cached_parent_json:
             return self.cached_parent_json
         return {}
+
+    def update_parent_json(self):
+        with Lock(f"tag_config_parent_cache:{self.id}"):
+            if self.parent_id:
+                self.cached_parent_json = {
+                    "id": str(self.parent.external_id),
+                    "display": self.parent.display,
+                    "description": self.parent.description,
+                    "category": self.parent.category,
+                    "parent": self.parent.cached_parent_json,
+                    "level_cache": self.parent.level_cache,
+                }
+                super().save(update_fields=["cached_parent_json"])
+
+    def update_child_cached_parent_json(self):
+        for child in TagConfig.objects.filter(parent=self).select_related("parent"):
+            child.update_parent_json()
+            child.update_child_cached_parent_json()
 
     def save(self, *args, **kwargs):
         if not self.id:
             super().save(*args, **kwargs)
             self.set_tag_config_cache()
+            self.update_parent_json()
         else:
             super().save(*args, **kwargs)
+            self.update_parent_json()
+            self.update_child_cached_parent_json()


### PR DESCRIPTION
## Proposed Changes

- Separated the logic for updating the parent JSON.
- get_parent_json() now only retrieves the cached parent JSON, regardless of cache expiry.
- Introduced update_parent_json() to update the cached parent JSON when a tag configuration is updated, while also refreshing the parent cache for all related child tags.


### Associated Issue

- ENG-807
## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving parent tag configurations.
  * Ensured updated tag configurations are reflected in related descendant configurations.
  * Prevented stale or incomplete configuration data from being displayed after changes.
  * Improved consistency of configuration data across nested tag relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->