### PR TITLE
fix(rounding): make get_rounding_class cache actually serve hits

### DIFF
--- a/care/utils/rounding/rounding.py
+++ b/care/utils/rounding/rounding.py
@@ -65,7 +65,7 @@ ROUNDING_CLASS = {}
 
 def get_rounding_class(method):
     global ROUNDING_CLASS  # noqa: PLW0602
-    if ROUNDING_CLASS.get(method) is not None and method is None:
+    if ROUNDING_CLASS.get(method) is not None:
         return ROUNDING_CLASS.get(method)
     module_name, _, class_name = method.rpartition(".")
     module = importlib.import_module(module_name)


### PR DESCRIPTION
### Problem

`get_rounding_class` in `care/utils/rounding/rounding.py` has an unreachable cache-hit branch:

```python
ROUNDING_CLASS = {}

def get_rounding_class(method):
    global ROUNDING_CLASS
    if ROUNDING_CLASS.get(method) is not None and method is None:
        return ROUNDING_CLASS.get(method)
    module_name, _, class_name = method.rpartition(".")
    ...
    ROUNDING_CLASS[method] = rounding_class
    return ROUNDING_CLASS[method]
```

Cache entries are written keyed by the non-None `method` string (`ROUNDING_CLASS[method] = rounding_class`), but the read guard also requires `method is None`. Those two conditions can never both hold, so the branch never runs. The result is that `ROUNDING_CLASS` is populated but never read, and every call (and therefore every `care_round`) re-runs `importlib.import_module` + `getattr` instead of returning the cached class.

### Fix

Drop the `and method is None` so a cached class is actually returned:

```python
if ROUNDING_CLASS.get(method) is not None:
    return ROUNDING_CLASS.get(method)
```

Behavior is unchanged (the same class is returned either way); this just lets the existing cache do its job. `import_module` is backed by `sys.modules`, so the effect is modest, but the condition as written is clearly not what was intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rounding method selection so supported methods consistently use their cached rounding implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->