### PR TITLE
fix: EMRResource.is_update raises TypeError

### DIFF
--- a/care/emr/resources/base.py
+++ b/care/emr/resources/base.py
@@ -45,7 +45,7 @@ class EMRResource(BaseModel):
         pass
 
     def is_update(self):
-        return getattr("_is_update", False)
+        return getattr(self, "_is_update", False)
 
     @classmethod
     def serialize(cls, obj: __model__, user=None, *args, **kwargs):

--- a/care/emr/tests/test_emr_resource.py
+++ b/care/emr/tests/test_emr_resource.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from care.emr.resources.base import EMRResource
+
+class DummyEMRResource(EMRResource):
+    pass
+
+class DummyEMRResourceUpdate(EMRResource):
+    _is_update = True
+
+class EMRResourceTestCase(TestCase):
+    def test_is_update_returns_false_by_default(self):
+        resource = DummyEMRResource()
+        self.assertFalse(resource.is_update())
+
+    def test_is_update_returns_true_when_set(self):
+        resource = DummyEMRResourceUpdate()
+        self.assertTrue(resource.is_update())


### PR DESCRIPTION
Fixes a TypeError crash in the `EMRResource` base class when checking `is_update()`.

The helper method was using `getattr("_is_update", False)` which tries to call `getattr` on a string literal instead of the instance itself, causing `TypeError: getattr(): attribute name must be string, not 'bool'`. 

I've updated it to look up the attribute on `self` instead, and added a quick test suite in `test_emr_resource.py` to verify the fix works and prevent regressions.
