### PR TITLE
[ENG-898] Fix validation error spelling mistake in sync invoice items

### DIFF
--- a/care/emr/resources/invoice/sync_items.py
+++ b/care/emr/resources/invoice/sync_items.py
@@ -58,7 +58,7 @@ def sync_invoice_items(invoice: Invoice):
         care_method=settings.INVOICE_FINAL_AMOUNT_ROUNDING_METHOD,
     )
     if not invoice.is_refund and (invoice.total_net < 0 or invoice.total_gross < 0):
-        raise ValidationError("A Refund Ivoice is required for negative values")
+        raise ValidationError("A Refund Invoice is required for negative values")
     invoice.total_price_components = json.loads(
         json.dumps(
             summary["total_price_components"],

--- a/care/emr/tests/test_invoice_api.py
+++ b/care/emr/tests/test_invoice_api.py
@@ -110,6 +110,49 @@ class TestAttachAccountToInvoice(CareAPITestBase):
         self.assertEqual(self.charge_item_1.paid_invoice, invoice)
         self.assertEqual(self.charge_item_2.paid_invoice, invoice)
 
+    def test_attach_account_to_invoice_rejects_negative_total_without_refund(self):
+        role = self.create_role_with_permissions(
+            [
+                InvoicePermissions.can_read_invoice.name,
+                InvoicePermissions.can_write_invoice.name,
+            ]
+        )
+        self.attach_role_facility_organization_user(self.organization, self.user, role)
+        self.client.force_authenticate(user=self.user)
+
+        baker.make(
+            "emr.ChargeItem",
+            facility=self.facility,
+            patient=self.patient,
+            encounter=self.encounter,
+            account=self.account,
+            status=ChargeItemStatusOptions.billable.value,
+            quantity=Decimal("1.00"),
+            unit_price_components=[{"amount": -500, "monetary_component_type": "base"}],
+            total_price_components=[
+                {"amount": -500, "monetary_component_type": "base"}
+            ],
+            total_price=Decimal("-500.00"),
+        )
+
+        invoice = baker.make(
+            "emr.Invoice",
+            facility=self.facility,
+            account=self.account,
+            patient=self.patient,
+            status=InvoiceStatusOptions.draft.value,
+            is_refund=False,
+            total_net=Decimal("0.00"),
+            total_gross=Decimal("0.00"),
+        )
+
+        response = self.client.post(self._get_url(invoice.external_id))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json()["errors"][0]["msg"],
+            "A Refund Invoice is required for negative values",
+        )
+
     def test_attach_account_to_invoice_requires_draft_status(self):
         role = self.create_role_with_permissions(
             [


### PR DESCRIPTION
## Proposed Changes

- ENG-898

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the validation error message shown when a non-refund invoice has a negative total.
  * Improved validation when attaching an account to an invoice with negative billable charges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->