### PR TITLE
[ENG-912] Add support for ordering and filtering by expiration date of product in inventory item's view-set

### DIFF
--- a/care/emr/api/viewsets/inventory/inventory_item.py
+++ b/care/emr/api/viewsets/inventory/inventory_item.py
@@ -20,6 +20,9 @@ class InventoryItemFilters(filters.FilterSet):
     product_knowledge = filters.UUIDFilter(
         field_name="product__product_knowledge__external_id"
     )
+    product_expiration_date = filters.DateTimeFromToRangeFilter(
+        field_name="product__expiration_date"
+    )
     status = filters.CharFilter(lookup_expr="iexact")
     net_content_gt = filters.NumberFilter(field_name="net_content", lookup_expr="gt")
     include_children = DummyBooleanFilter()
@@ -32,7 +35,12 @@ class InventoryItemViewSet(EMRRetrieveMixin, EMRListMixin, EMRBaseViewSet):
     pydantic_retrieve_model = InventoryItemRetrieveSpec
     filterset_class = InventoryItemFilters
     filter_backends = [filters.DjangoFilterBackend, OrderingFilter]
-    ordering_fields = ["created_date", "modified_date", "net_content"]
+    ordering_fields = [
+        "created_date",
+        "modified_date",
+        "net_content",
+        "product__expiration_date",
+    ]
 
     def get_location_obj(self):
         return get_object_or_404(

--- a/care/emr/tests/test_inventory_item_api.py
+++ b/care/emr/tests/test_inventory_item_api.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.urls import reverse
 from model_bakery import baker
 
@@ -199,6 +201,29 @@ class InventoryItemAPITest(CareAPITestBase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["id"], str(inventory.external_id))
+
+    def test_listing_inventory_items_product_expiration_date_filter(self):
+        self.client.force_authenticate(user=self.super_user)
+        now = datetime.datetime.now(datetime.UTC)
+        unexpired_inventory = self.create_inventory_item(
+            facility=self.facility,
+            location=self.facility_location,
+            expiration_date=now + datetime.timedelta(days=30),
+        )
+        self.create_inventory_item(
+            facility=self.facility,
+            location=self.facility_location,
+            expiration_date=now - datetime.timedelta(days=30),
+        )
+        response = self.client.get(
+            self.base_url,
+            {"product_expiration_date_after": now.date().isoformat()},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(
+            response.data["results"][0]["id"], str(unexpired_inventory.external_id)
+        )
 
     def test_listing_inventory_items_include_children_filter(self):
         self.client.force_authenticate(user=self.super_user)


### PR DESCRIPTION
## Proposed Changes

- Adds support for ordering by `product_expiration_date` on inventory item's viewset
- Adds `product_expiration_date` date time range filter on inventory item's viewset
- Adds test for the filter

### Associated Issue

- ENG-912

## Merge Checklist

- [x] Tests added/fixed
- [x] Linting Complete

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inventory item filtering by product expiration date.
  * Added support for sorting inventory items by product expiration date.
* **Bug Fixes**
  * Improved inventory item listings to return accurate results when filtering for expired or unexpired products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->