### PR TITLE
fix: authorize note retrieve from the thread's encounter

### DIFF
--- a/care/emr/api/viewsets/notes.py
+++ b/care/emr/api/viewsets/notes.py
@@ -26,6 +26,16 @@ from care.utils.filters.null_filter import NullFilter
 from care.utils.shortcuts import get_object_or_404
 
 
+def authorize_notes_view(user, patient, encounter=None):
+    if AuthorizationController.call("can_view_clinical_data", user, patient):
+        return
+    if encounter and AuthorizationController.call(
+        "can_view_encounter_clinical_data", user, encounter
+    ):
+        return
+    raise PermissionDenied("Permission denied to user")
+
+
 class NoteThreadFilters(filters.FilterSet):
     encounter = filters.UUIDFilter(field_name="encounter__external_id")
     encounter_isnull = NullFilter(field_name="encounter")
@@ -86,25 +96,22 @@ class NoteThreadViewSet(
         super().perform_create(instance)
 
     def get_object(self):
-        # TODO Authorise Based on encounter and permission
-        return super().get_object()
+        patient = self.get_patient()
+        obj = get_object_or_404(
+            self.database_model,
+            patient=patient,
+            **{self.lookup_field: self.kwargs[self.lookup_field]},
+        )
+        authorize_notes_view(self.request.user, patient, obj.encounter)
+        return obj
 
     def get_queryset(self):
         patient = self.get_patient()
-        if not AuthorizationController.call(
-            "can_view_clinical_data", self.request.user, patient
-        ):
-            if encounter := self.request.GET.get("encounter"):
-                encounter_obj = get_object_or_404(Encounter, external_id=encounter)
-                if not AuthorizationController.call(
-                    "can_view_encounter_clinical_data", self.request.user, encounter_obj
-                ):
-                    raise PermissionDenied("Permission denied to user")
-            else:
-                raise PermissionDenied("Permission denied to user")
-
-        queryset = super().get_queryset().filter(patient=patient)
-        return queryset.order_by("-created_date")
+        encounter_obj = None
+        if encounter := self.request.GET.get("encounter"):
+            encounter_obj = get_object_or_404(Encounter, external_id=encounter)
+        authorize_notes_view(self.request.user, patient, encounter_obj)
+        return super().get_queryset().filter(patient=patient).order_by("-created_date")
 
 
 class NoteMessageViewSet(
@@ -170,18 +177,21 @@ class NoteMessageViewSet(
         if model_instance.thread != thread:
             raise ValidationError("Message does not belong to the thread")
 
+    def get_object(self):
+        thread = self.get_thread_obj()
+        obj = get_object_or_404(
+            self.database_model,
+            **{self.lookup_field: self.kwargs[self.lookup_field]},
+        )
+        authorize_notes_view(self.request.user, thread.patient, thread.encounter)
+        return obj
+
     def get_queryset(self):
-        if not AuthorizationController.call(
-            "can_view_clinical_data", self.request.user, self.get_patient_obj()
-        ):
-            if encounter := self.request.GET.get("encounter"):
-                encounter_obj = get_object_or_404(Encounter, external_id=encounter)
-                if not AuthorizationController.call(
-                    "can_view_encounter_clinical_data", self.request.user, encounter_obj
-                ):
-                    raise PermissionDenied("Permission denied to user")
-            else:
-                raise PermissionDenied("Permission denied to user")
+        patient = self.get_patient_obj()
+        encounter_obj = None
+        if encounter := self.request.GET.get("encounter"):
+            encounter_obj = get_object_or_404(Encounter, external_id=encounter)
+        authorize_notes_view(self.request.user, patient, encounter_obj)
         queryset = super().get_queryset().select_related("thread")
         if self.action == "list":
             thread = self.get_thread_obj()

--- a/care/emr/tests/test_notes_api.py
+++ b/care/emr/tests/test_notes_api.py
@@ -192,6 +192,52 @@ class NoteThreadApiTestCase(CareAPITestBase):
         self.assertEqual(response.status_code, 403, response.data)
         self.assertContains(response, "Permission denied to user", status_code=403)
 
+    def test_retrieve_thread(self):
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_view_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        url = self._get_thread_detail_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, thread.title, status_code=200)
+
+    def test_retrieve_thread_without_permission(self):
+        thread = self._create_thread()
+        url = self._get_thread_detail_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
+    def test_retrieve_thread_on_encounter(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_read_encounter_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread(encounter=self.encounter)
+        url = self._get_thread_detail_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, thread.title, status_code=200)
+
+    def test_retrieve_patient_thread_with_only_encounter_permission(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_read_encounter_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        url = self._get_thread_detail_url(thread.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
 
 class NoteMessageApiTestCase(CareAPITestBase):
     def setUp(self):
@@ -320,6 +366,56 @@ class NoteMessageApiTestCase(CareAPITestBase):
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, 200, response.data)
         self.assertContains(response, note.message, status_code=200)
+
+    def test_retrieve_note(self):
+        role = self.create_role_with_permissions(
+            permissions=[PatientPermissions.can_view_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, note.message, status_code=200)
+
+    def test_retrieve_note_without_permission(self):
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
+
+    def test_retrieve_note_on_encounter(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_read_encounter_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread(encounter=self.encounter)
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 200, response.data)
+        self.assertContains(response, note.message, status_code=200)
+
+    def test_retrieve_note_on_patient_thread_with_only_encounter_permission(self):
+        role = self.create_role_with_permissions(
+            permissions=[EncounterPermissions.can_read_encounter_clinical_data.name]
+        )
+        self.attach_role_facility_organization_user(
+            self.facility_organization, self.user, role
+        )
+        thread = self._create_thread()
+        note = self._create_note(thread)
+        url = self._get_note_detail_url(thread.external_id, note.external_id)
+        response = self.client.get(url, format="json")
+        self.assertEqual(response.status_code, 403, response.data)
+        self.assertContains(response, "Permission denied to user", status_code=403)
 
     def test_get_note_details_with_invalid_thread(self):
         self.client.force_authenticate(user=self.superuser)


### PR DESCRIPTION
## Proposed Changes

- `NoteThread` / `NoteMessage` detail now checks view permission against the thread's encounter, instead of only looking at `?encounter=` on the request.
- Encounter-scoped users can retrieve (and therefore update) a thread they can already list. Patient-level threads still require `can_view_clinical_data`.
- Pulled the duplicated list/detail check into one helper.

### Associated Issue

`get_object` had a leftover TODO (`Authorise Based on encounter and permission`) and just called `super().get_object()`, which goes through `get_queryset`. That queryset only treats encounter access when `?encounter=` is present, so it never is on `/thread/{id}/` or `/notes/{id}/`.

List with `?encounter=` already returned 200 for `can_read_encounter_clinical_data`; GET on the same thread returned 403.

## Merge Checklist

- [x] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins