### PR TITLE
[ENG-986] Include facility identifiers in dispense order patient

### DIFF
--- a/care/emr/resources/medication/dispense/dispense_order.py
+++ b/care/emr/resources/medication/dispense/dispense_order.py
@@ -75,4 +75,6 @@ class MedicationDispenseOrderRetrieveSpec(MedicationDispenseOrderReadSpec):
         cls.serialize_audit_users(mapping, obj)
         mapping["id"] = obj.external_id
         mapping["location"] = FacilityLocationListSpec.serialize(obj.location).to_json()
-        mapping["patient"] = PatientRetrieveSpec.serialize(obj.patient).to_json()
+        mapping["patient"] = PatientRetrieveSpec.serialize(
+            obj.patient, facility=obj.facility
+        ).to_json()


### PR DESCRIPTION
## Summary

`MedicationDispenseOrderRetrieveSpec` serialized the patient with `PatientRetrieveSpec.serialize(obj.patient)` and no facility in context, so `facility_identifiers` was always empty on the dispense order retrieve payload. Every other facility-scoped serializer that embeds a patient (encounter, account, diagnostic report, service request, token booking, payment reconciliation) already passes `facility=`. This passes `obj.facility` so the dispense order view and print can show facility-level patient identifiers.

Companion frontend PR: https://github.com/ohcnetwork/care_fe/pull/16765

## Verification

`care.emr.tests.test_dispense_order_api` — 33 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medication dispense order details now serialize patient information using the correct facility context, improving the accuracy and consistency of displayed patient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->