### PR TITLE
[ENG-988] added constructor to NoOpLock in fixtures 

### DIFF
--- a/care/fixtures/context.py
+++ b/care/fixtures/context.py
@@ -18,7 +18,10 @@ sys.modules["care.emr.utils.valueset_coding_type"].validate_valueset = lambda f,
 
 
 class _NoOpLock:
-    """Bypass PatientCreateLock inside an outer transaction."""
+    """Bypass create locks inside an outer transaction."""
+
+    def __init__(self, *args, **kwargs):
+        pass
 
     def acquire(self):
         pass
@@ -44,6 +47,10 @@ def care_fixture_context(base_cls: type[CareFixtureBase] = CareFixtureBase):
         with (
             transaction.atomic(),
             patch("care.emr.api.viewsets.patient.PatientCreateLock", _NoOpLock),
+            patch(
+                "care.emr.api.viewsets.encounter.FacilityEncounterCreateLock",
+                _NoOpLock,
+            ),
             warnings.catch_warnings(),
         ):
             warnings.filterwarnings(


### PR DESCRIPTION
## Proposed Changes

- added constructor to NoOpLock in fixtures so it accepts arg for `FacilityEncounterCreateLock`

### Associated Issue

- Link to issue here, explain how the proposed solution will solve the reported issue/ feature request.

### Architecture changes

- Remove this section if not used

## Merge Checklist

- [ ] Tests added/fixed
- [ ] Update docs in `/docs`
- [ ] Linting Complete
- [ ] Any other necessary step

_*Only PR's with test cases included and passing lint and test pipelines will be reviewed*_

@ohcnetwork/care-backend-maintainers @ohcnetwork/care-backend-admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated care fixture behavior to bypass facility encounter creation locks within outer transactions.
  * Improved fixture compatibility by allowing the no-op lock to accept arbitrary initialization arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->