### PR TITLE
[ENG-998] Move collectstatic to Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,7 +321,11 @@ tags
 
 ### VirtualEnv template
 # Virtualenv
-[Bb]in
+[Bb]in/
+!bin/
+bin/*
+!bin/pre_compile
+!bin/post_compile
 [Ii]nclude
 [Ll]ib
 [Ll]ib64

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn config.wsgi:application
-release: python manage.py collectstatic --noinput && python manage.py migrate
+release: python manage.py migrate

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+python install_plugins.py
+bash scripts/build_assets.sh -v 0

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ -n "${ENV_DIR:-}" ] && [ -d "$ENV_DIR" ]; then
+  printf "1" > "$ENV_DIR/DISABLE_COLLECTSTATIC"
+else
+  mkdir -p .heroku
+  touch .heroku/collectstatic_disabled
+fi

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -28,6 +28,10 @@ COPY . $APP_HOME/
 
 RUN --mount=type=cache,target=/root/.cache/pip python3 $APP_HOME/install_plugins.py
 
+RUN DJANGO_SETTINGS_MODULE=config.settings.local \
+  ADDITIONAL_PLUGS="$ADDITIONAL_PLUGS" \
+  bash $APP_HOME/scripts/build_assets.sh -v 0
+
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -56,11 +56,15 @@ COPY --from=builder --chown=django:django $APP_HOME/.venv $APP_HOME/.venv
 ARG APP_VERSION="unknown"
 ENV APP_VERSION=$APP_VERSION
 
+ARG ADDITIONAL_PLUGS=""
+
 COPY --chmod=0755 --chown=django:django ./scripts/*.sh $APP_HOME
 
 COPY --chown=django:django . $APP_HOME
 
 USER django
+
+RUN ADDITIONAL_PLUGS="$ADDITIONAL_PLUGS" ./scripts/build_assets.sh -v 0
 
 HEALTHCHECK \
   --interval=30s \

--- a/scripts/build_assets.sh
+++ b/scripts/build_assets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-config.settings.deployment}"
+export DATABASE_URL="${DATABASE_URL:-postgres://postgres:postgres@localhost:5432/care}"
+export REDIS_URL="${REDIS_URL:-redis://localhost:6379/0}"
+
+python manage.py compilemessages -v 0
+python manage.py collectstatic --noinput "$@"

--- a/scripts/celery_beat.sh
+++ b/scripts/celery_beat.sh
@@ -16,7 +16,6 @@ fi
 ./wait_for_redis.sh
 
 python manage.py migrate --noinput
-python manage.py compilemessages -v 0
 python manage.py sync_permissions_roles
 python manage.py sync_valueset
 

--- a/scripts/celery_worker.sh
+++ b/scripts/celery_worker.sh
@@ -15,7 +15,4 @@ fi
 ./wait_for_db.sh
 ./wait_for_redis.sh
 
-python manage.py collectstatic --noinput
-python manage.py compilemessages -v 0
-
 celery --app=config.celery_app worker --max-tasks-per-child=6 --loglevel=info --concurrency=${CELERY_WORKER_CONCURRENCY:-1}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -21,9 +21,5 @@ GUNICORN_WORKERS="${GUNICORN_WORKERS:="2"}"
 ./wait_for_db.sh
 ./wait_for_redis.sh
 
-python manage.py collectstatic --noinput
-python manage.py compilemessages -v 0
-
-
 gunicorn --config python:config.gunicorn config.wsgi:application --bind 0.0.0.0:9000 --chdir=/app --workers $GUNICORN_WORKERS \
   --access-logformat "$GUNICORN_LOG_FORMAT" --access-logfile $GUNICORN_ACCESS_LOGFILE --error-logfile $GUNICORN_ERROR_LOGFILE


### PR DESCRIPTION
## Proposed Changes

Move `collectstatic` and `compilemessages` to build time instead of run time. 

### Associated Issue

ENG-998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment**
  - Asset collection and translation compilation now occur during the build process rather than at application startup.
  - Release and service startup workflows no longer run static-asset collection or translation compilation.
  - Docker builds now support configured additional plugins and automatically prepare required assets.

- **Reliability**
  - Build and deployment scripts now stop promptly when errors occur, helping prevent incomplete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->